### PR TITLE
Fix swapped variable in searchType/searchContent error messages

### DIFF
--- a/src/main/java/org/gbif/taxon/provider/NameUsageSearchRequestHandlerMethodArgumentResolver.java
+++ b/src/main/java/org/gbif/taxon/provider/NameUsageSearchRequestHandlerMethodArgumentResolver.java
@@ -67,7 +67,7 @@ public class NameUsageSearchRequestHandlerMethodArgumentResolver
       try {
         req.setSearchType(NameUsageSearchRequest.SearchType.valueOf(searchType.toUpperCase()));
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Unknown searchType value: " + sortBy +
+        throw new IllegalArgumentException("Unknown searchType value: " + searchType +
             ". Valid values are: " + Arrays.toString(NameUsageSearchRequest.SearchType.values()));
       }
     }
@@ -81,7 +81,7 @@ public class NameUsageSearchRequestHandlerMethodArgumentResolver
                 .collect(Collectors.toSet())
         );
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("Unknown searchContent value: " + sortBy +
+        throw new IllegalArgumentException("Unknown searchContent value: " + Arrays.toString(searchContent) +
             ". Valid values are: " + Arrays.toString(NameUsageSearchRequest.SearchContent.values()));
       }
     }


### PR DESCRIPTION
## Problem

`/v2/experimental/taxon/search/{datasetKey}?searchType=FUZZY&sortBy=RELEVANCE` returned:

```
Unknown searchType value: RELEVANCE. Valid values are: [STANDARD, EXACT]
```

`RELEVANCE` was passed as `sortBy`, not `searchType` — making it look like the parameters were swapped.

## Cause

In `NameUsageSearchRequestHandlerMethodArgumentResolver.getSearchRequest`, the `searchType` and `searchContent` validation blocks were copy-pasted from the `sortBy` block but never updated their error messages — both interpolated the `sortBy` value. So an invalid `searchType` (e.g. `FUZZY`, removed in ccf73fe) was correctly rejected, but the message printed the unrelated `sortBy` value.

## Fix

- `searchType` error now names the actual `searchType` value → `Unknown searchType value: FUZZY. Valid values are: [STANDARD, EXACT]`
- `searchContent` error now names the offending `searchContent[]` value

Note: `FUZZY` is still (correctly) rejected — fuzzy search was intentionally removed in ccf73fe. This only makes the error message accurate.

Verified with `mvn clean compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)